### PR TITLE
Add readUInt48BE and readUInt64BE

### DIFF
--- a/bench/readUInt48BE.js
+++ b/bench/readUInt48BE.js
@@ -1,0 +1,36 @@
+var init = require('./init')
+var looper = require('looper')
+
+module.exports = function (blocks, cb) {
+  init(blocks, 100, function (err) {
+    if(err) throw err
+
+    var start = Date.now()
+    var c = 0
+    var next = looper(function () {
+      var seconds = (Date.now() - start)/1000
+      if(seconds > 1)
+        return cb(null, c / seconds, c, seconds)
+      var index = Math.min(Math.floor(Math.random()*blocks.size()), blocks.size() - 6)
+      blocks.readUInt48BE(index, function (err, n) {
+        if(err) return cb(err)
+        c++
+        next()
+      })
+
+    })
+    console.log('start loop')
+    next()
+  })
+}
+
+if(!module.parent) {
+  var blocks = require('../')('/tmp/bench-abf'+Date.now(), 1024, 'a+')
+  module.exports(blocks, function (err, ps, ops, seconds) {
+    console.log(err, ps, ops, seconds)
+  })
+}
+
+
+
+

--- a/bench/readUInt64BE.js
+++ b/bench/readUInt64BE.js
@@ -1,0 +1,45 @@
+var looper = require('looper')
+
+function init(blocks, n, cb) {
+  ;(function next (i) {
+    if(i == n) return cb(null, blocks)
+    blocks.append(Buffer.alloc(10).fill(0), function (err) {
+      if(err) cb(err)
+      else next(i + 1)
+    })
+  })(0)
+}
+
+module.exports = function (blocks, cb) {
+  init(blocks, 100, function (err) {
+    if(err) throw err
+
+    var start = Date.now()
+    var c = 0
+    var next = looper(function () {
+      var seconds = (Date.now() - start)/1000
+      if(seconds > 1)
+        return cb(null, c / seconds, c, seconds)
+      var index = Math.min(Math.floor(Math.random()*blocks.size()), blocks.size() - 8)
+      blocks.readUInt64BE(index, function (err, n) {
+        if(err) return cb(err)
+        c++
+        next()
+      })
+
+    })
+    console.log('start loop')
+    next()
+  })
+}
+
+if(!module.parent) {
+  var blocks = require('../')('/tmp/bench-abf'+Date.now(), 1024, 'a+')
+  module.exports(blocks, function (err, ps, ops, seconds) {
+    console.log(err, ps, ops, seconds)
+  })
+}
+
+
+
+

--- a/blocks.js
+++ b/blocks.js
@@ -39,7 +39,7 @@ module.exports = function (file, block_size, cache) {
   function read(start, end, cb) {
     assertInteger(start);assertInteger(end)
     //check if start & end are part of the same buffer
-    var i = ~~(start/block_size)
+    var i = Math.floor(start/block_size)
     if(file && end > file.offset.value)
       return cb(new Error('past end'), null, 0)
     var bufs = []

--- a/blocks.js
+++ b/blocks.js
@@ -1,5 +1,6 @@
 var fs = require('fs')
 var uint48be = require('uint48be')
+var int53 = require('int53')
 
 /*
   Represent a file, as a table of buffers.
@@ -108,6 +109,9 @@ module.exports = function (file, block_size, cache) {
     }),
     readUInt48BE: readInteger(6, function(b, offset) {
       return uint48be.decode(b, offset)
+    }),
+    readUInt64BE: readInteger(8, function(b, offset) {
+      return int53.readUInt64BE(b, offset)
     }),
     size: file && file.size,
     offset: file && file.offset,

--- a/blocks.js
+++ b/blocks.js
@@ -125,7 +125,7 @@ module.exports = function (file, block_size, cache) {
 
         var start = _offset
         var b_start = 0
-        var i = ~~(start/block_size)
+        var i = Math.floor(start/block_size)
         if(i*block_size < _offset) //usually true, unless file length is multiple of block_size
           get(i, function (err) { //this will add the last block to the cache.
             if(err) cb(explain(err, 'precache before append failed'))

--- a/blocks.js
+++ b/blocks.js
@@ -97,7 +97,8 @@ module.exports = function (file, block_size, cache) {
       else
         read(start, start+width, function (err, buf, bytes_read) {
           if(err) return cb(err)
-          cb(null, reader(buf, 0))
+          var value = reader(buf, 0);
+          cb(isNaN(value) ? new Error('Number is too large') : null, value)
         })
     }
   }
@@ -111,7 +112,12 @@ module.exports = function (file, block_size, cache) {
       return uint48be.decode(b, offset)
     }),
     readUInt64BE: readInteger(8, function(b, offset) {
-      return int53.readUInt64BE(b, offset)
+      // int53.readUInt64BE will throw if number is too large
+      try {
+        return int53.readUInt64BE(b, offset)
+      } catch(err) {
+        return NaN;
+      }
     }),
     size: file && file.size,
     offset: file && file.offset,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "hashlru": "^2.1.0",
     "mkdirp": "^0.5.1",
-    "obv": "0.0.0"
+    "obv": "0.0.0",
+    "uint48be": "^1.0.0"
   },
   "devDependencies": {
     "looper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "int53": "^0.2.4",
     "mkdirp": "^0.5.1",
     "obv": "0.0.0",
-    "uint48be": "^1.0.0"
+    "uint48be": "^1.0.1"
   },
   "devDependencies": {
     "looper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "hashlru": "^2.1.0",
+    "int53": "^0.2.4",
     "mkdirp": "^0.5.1",
     "obv": "0.0.0",
     "uint48be": "^1.0.0"

--- a/test/read-integers.js
+++ b/test/read-integers.js
@@ -64,20 +64,21 @@ tape('readUInt64BE', function (t) {
   cache.set(4, new Buffer.from('ffffffffaaaaaaaa', 'hex'))
   var blocks = Blocks(null, 8, cache)
 
-  t.plan(4)
+  t.plan(5)
   test(0, 2) // aligned
   test(1, 513) //unaligned
   test(16, Math.pow(2,53)-1) // maxint
   test(28, Math.pow(2,53)-1) // maxint, unaligned
+  test(29, NaN, true) // overflow!
 
-  function test(offset, expected) {
+  function test(offset, expected, expectError) {
     blocks.readUInt64BE(offset, function (err, n) {
-      if (err) throw err
-      t.equal(n, expected)
+      if (err && !expectError) throw err
+      if (!err && expectError) throw new Error('Expected error dir not occur')
+      if (!err)
+        t.equal(n, expected)
+      else
+        t.equal(isNaN(n), true)
     })
   }
 })
-
-
-
-

--- a/test/read-integers.js
+++ b/test/read-integers.js
@@ -1,0 +1,83 @@
+var tape = require('tape')
+var Blocks = require('../blocks')
+
+function Cache () {
+  var c = []
+  return {
+    get: function (key) { return c[key] },
+    set: function (key, value) { c[key] = value }
+  }
+}
+
+tape('readUInt32BE', function (t) {
+  var cache = Cache()
+  cache.set(0, new Buffer.from('00000002', 'hex'))
+  cache.set(1, new Buffer.from('01000000', 'hex'))
+  cache.set(2, new Buffer.from('ffffffff', 'hex'))
+  cache.set(3, new Buffer.from('aaaaffff', 'hex'))
+  cache.set(4, new Buffer.from('ffffaaaa', 'hex'))
+  var blocks = Blocks(null, 4, cache)
+
+  t.plan(4)
+  test(0, 2) // aligned
+  test(1, 513) //unaligned
+  test(8, Math.pow(2,32)-1) // maxint
+  test(14, Math.pow(2,32)-1) // maxint, unaligned
+
+  function test(offset, expected) {
+    blocks.readUInt32BE(offset, function (err, n) {
+      if (err) throw err
+      t.equal(n, expected)
+    })
+  }
+})
+
+tape('readUInt48BE', function (t) {
+  var cache = Cache()
+  cache.set(0, new Buffer.from('000000000002', 'hex'))
+  cache.set(1, new Buffer.from('010000000000', 'hex'))
+  cache.set(2, new Buffer.from('ffffffffffff', 'hex'))
+  cache.set(3, new Buffer.from('aaaaaaffffff', 'hex'))
+  cache.set(4, new Buffer.from('ffffffaaaaaa', 'hex'))
+  var blocks = Blocks(null, 6, cache)
+
+  t.plan(4)
+  test(0, 2) // aligned
+  test(1, 513) //unaligned
+  test(12, Math.pow(2,48)-1) // maxint
+  test(21, Math.pow(2,48)-1) // maxint, unaligned
+
+  function test(offset, expected) {
+    blocks.readUInt48BE(offset, function (err, n) {
+      if (err) throw err
+      t.equal(n, expected)
+    })
+  }
+})
+
+tape('readUInt64BE', function (t) {
+  var cache = Cache()
+  cache.set(0, new Buffer.from('0000000000000002', 'hex'))
+  cache.set(1, new Buffer.from('0100000000000000', 'hex'))
+  cache.set(2, new Buffer.from('001fffffffffffff', 'hex'))
+  cache.set(3, new Buffer.from('aaaaaaaa001fffff', 'hex'))
+  cache.set(4, new Buffer.from('ffffffffaaaaaaaa', 'hex'))
+  var blocks = Blocks(null, 8, cache)
+
+  t.plan(4)
+  test(0, 2) // aligned
+  test(1, 513) //unaligned
+  test(16, Math.pow(2,53)-1) // maxint
+  test(28, Math.pow(2,53)-1) // maxint, unaligned
+
+  function test(offset, expected) {
+    blocks.readUInt64BE(offset, function (err, n) {
+      if (err) throw err
+      t.equal(n, expected)
+    })
+  }
+})
+
+
+
+


### PR DESCRIPTION
According to bench/readUnit32BE.js there is no significant performance hit due to this change. readUint48 seems to be nearly as fast as readUnit32, while readUint64 is way less then half the speed of readUInt32. I had to change the benchmark for 64 integers (reading buffers of zeros) to not randomly hit a number overflow assertion.

Are you okay with the additional dependencies or should they be injected?

related to and needed for: https://github.com/flumedb/flumelog-offset/issues/2