### PR TITLE
Add write method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/bench/append.js
+++ b/bench/append.js
@@ -9,7 +9,7 @@ module.exports = function (ABF) {
   }
 
   require('./')(ABF, {
-    data: new Buffer(1024*16),
+    data: new Buffer.alloc(1024*16),
     time:10e3, size: 100e6,
     onUpdate: log
   }, function (err, size, time) {

--- a/bench/readUInt64BE.js
+++ b/bench/readUInt64BE.js
@@ -3,7 +3,7 @@ var looper = require('looper')
 function init(blocks, n, cb) {
   ;(function next (i) {
     if(i == n) return cb(null, blocks)
-    blocks.append(Buffer.alloc(10).fill(0), function (err) {
+    blocks.append(Buffer.alloc(10), function (err) {
       if(err) cb(err)
       else next(i + 1)
     })

--- a/blocks.js
+++ b/blocks.js
@@ -139,8 +139,7 @@ module.exports = function (file, block_size, cache) {
             var block_start = i*block_size
             var b = cache.get(i)
             if(null == b) {
-              b = new Buffer(block_size)
-              b.fill(0)
+              b = Buffer.alloc(block_size)
               cache.set(i, b)
             }
             //including if set in above if...

--- a/blocks.js
+++ b/blocks.js
@@ -64,6 +64,14 @@ module.exports = function (file, block_size, cache) {
           next(i+1)
         } else {
           var buffer = bufs.length == 1 ? bufs[0] : Buffer.concat(bufs)
+          if (!buffer.length)
+            return cb(new Error('read an empty buffer at:'+start + ' to ' + end + '\n'+
+              JSON.stringify({
+                start: start, end: end, i:i,
+                bytes_read: bytes_read,
+                bufs: bufs
+              }))
+            )
           cb(null, buffer, bytes_read)
         }
       })

--- a/blocks.js
+++ b/blocks.js
@@ -60,17 +60,10 @@ module.exports = function (file, block_size, cache) {
         bufs.push(block.slice(read_start, read_end))
         start += (read_end - read_start)
 
-        if(start < end) next(i+1)
-        else {
+        if (start < end) {
+          next(i+1)
+        } else {
           var buffer = bufs.length == 1 ? bufs[0] : Buffer.concat(bufs)
-          if(!buffer.length)
-            return cb(new Error('read an empty buffer at:'+start + ' to ' + end + '\n'+
-              JSON.stringify({
-                start: start, end: end, i:i,
-                bytes_read: bytes_read,
-                bufs: bufs
-              }))
-            )
           cb(null, buffer, bytes_read)
         }
       })
@@ -173,6 +166,19 @@ module.exports = function (file, block_size, cache) {
           })
         }
       })
+    },
+    /**
+     * Writes a buffer directly to a position in the file.
+     * This wraps `file.write()` and removes the block cache.
+     *
+     * @param {buffer} buf - the data to write to the file
+     * @param {number} pos - position in the file to write the buffer
+     * @param {function} cb - callback that returns any error as an argument
+     */
+    write: (buf, pos, cb) => {
+      const i = Math.floor(pos/block_size)
+      cache.remove(i)
+      file.write(buf, pos, cb)
     },
     //we arn't specifically clearing the buffers,
     //but they should get updated anyway.

--- a/blocks.js
+++ b/blocks.js
@@ -176,7 +176,8 @@ module.exports = function (file, block_size, cache) {
     },
     /**
      * Writes a buffer directly to a position in the file.
-     * This wraps `file.write()` and removes the block cache.
+     * This wraps `file.write()` and removes the block cache after the file
+     * write finishes to avoid having the item re-cached during the write.
      *
      * @param {buffer} buf - the data to write to the file
      * @param {number} pos - position in the file to write the buffer
@@ -184,8 +185,10 @@ module.exports = function (file, block_size, cache) {
      */
     write: (buf, pos, cb) => {
       const i = Math.floor(pos/block_size)
-      cache.remove(i)
-      file.write(buf, pos, cb)
+      file.write(buf, pos, (err) => {
+        cache.remove(i)
+        cb(err)
+      })
     },
     //we arn't specifically clearing the buffers,
     //but they should get updated anyway.

--- a/file.js
+++ b/file.js
@@ -23,11 +23,17 @@ module.exports = function (file, block_size, flags) {
   return {
     get: function (i, cb) {
       offset.once(function (_offset) {
-        writing(function (_writing, rm) {
+        let shouldRemove = false
+        const rm = writing(function (_writing) {
+          if (shouldRemove === true) {
+            return rm()
+          }
+
+
           if (_writing === true) {
             return
           } else {
-            rm()
+            shouldRemove = true
           }
 
           var max = ~~(_offset / block_size)
@@ -91,12 +97,17 @@ module.exports = function (file, block_size, flags) {
           return cb(new Error(`cannot write past offset: ${endPos} > ${_offset}`))
         }
 
-        writing(function (_writing, rm) {
+        let shouldRemove = false
+        const rm = writing(function (_writing) {
+          if (shouldRemove === true) {
+            return rm()
+          }
+
           if (_writing === true) {
             return
           } else {
-            rm()
             writing.set(true)
+            shouldRemove = true
           }
 
           fs.open(file, 'r+', function (err, writeFd) {

--- a/file.js
+++ b/file.js
@@ -17,18 +17,18 @@ module.exports = function (file, block_size, flags) {
     })
   })
 
+  // This variable *only* tracks appends, not positional writes.
   var appending = 0
 
   return {
     get: function (i, cb) {
       offset.once(function (_offset) {
-        writing(function (_writing) {
+        writing(function (_writing, rm) {
           if (_writing === true) {
             return
           } else {
-            this()
+            rm()
           }
-
 
           var max = ~~(_offset / block_size)
           if(i > max)
@@ -91,11 +91,11 @@ module.exports = function (file, block_size, flags) {
           return cb(new Error(`cannot write past offset: ${endPos} > ${_offset}`))
         }
 
-        writing(function (_writing) {
+        writing(function (_writing, rm) {
           if (_writing === true) {
             return
           } else {
-            this()
+            rm()
             writing.set(true)
           }
 

--- a/file.js
+++ b/file.js
@@ -4,9 +4,9 @@ var Obv = require('obv')
 var path = require('path')
 
 module.exports = function (file, block_size, flags) {
-  var self
   var fd = Obv()
   var offset = Obv()
+  var writing = Obv().set(false)
   //fs.openSync(file, flags || 'r+')
   mkdirp(path.dirname(file), function () {
     fs.open(file, flags || 'r+', function (err, _fd) {
@@ -17,45 +17,54 @@ module.exports = function (file, block_size, flags) {
     })
   })
 
-  var writing = 0
+  var appending = 0
 
-  return self = {
+  return {
     get: function (i, cb) {
       offset.once(function (_offset) {
-        var max = ~~(_offset / block_size)
-        if(i > max)
-          return cb(new Error('aligned-block-file/file.get: requested block index was greater than max, got:'+i+', expected less than or equal to:'+max))
+        writing(function (_writing) {
+          if (_writing === true) {
+            return
+          } else {
+            this()
+          }
 
-        var buf = Buffer.alloc(block_size)
 
-        fs.read(fd.value, buf, 0, block_size, i*block_size, function (err, bytes_read) {
-          if(err) cb(err)
-          else if(
-            //if bytes_read is wrong
-            i < max &&
-            buf.length !== bytes_read &&
-            //unless this is the very last block and it is incomplete.
-            !((i*block_size + bytes_read) == offset.value)
-          )
-            cb(new Error(
-              'aligned-block-file/file.get: did not read whole block, expected length:'+
-              block_size+' but got:'+bytes_read
-            ))
-          else
-            cb(null, buf, bytes_read)
+          var max = ~~(_offset / block_size)
+          if(i > max)
+            return cb(new Error('aligned-block-file/file.get: requested block index was greater than max, got:'+i+', expected less than or equal to:'+max))
+
+          var buf = Buffer.alloc(block_size)
+
+          fs.read(fd.value, buf, 0, block_size, i*block_size, function (err, bytes_read) {
+            if(err) cb(err)
+            else if(
+              //if bytes_read is wrong
+              i < max &&
+              buf.length !== bytes_read &&
+              //unless this is the very last block and it is incomplete.
+              !((i*block_size + bytes_read) == offset.value)
+            )
+              cb(new Error(
+                'aligned-block-file/file.get: did not read whole block, expected length:'+
+                block_size+' but got:'+bytes_read
+              ))
+            else
+              cb(null, buf, bytes_read)
+          })
         })
       })
     },
     offset: offset,
     size: function () { return offset.value },
     append: function (buf, cb) {
-      if(writing++) throw new Error('already writing to this file')
+      if(appending++) throw new Error('already appending to this file')
       fd.once(function (_fd) {
         if('object' === typeof _fd)
           return cb(_fd)
         offset.once(function (_offset) {
           fs.write(_fd, buf, 0, buf.length, _offset, function (err, written) {
-            writing = 0
+            appending = 0
             if(err) return cb(err)
             if(written !== buf.length) return cb(new Error('wrote less bytes than expected:'+written+', but wanted:'+buf.length))
             offset.set(_offset+written)
@@ -74,20 +83,37 @@ module.exports = function (file, block_size, flags) {
      * @param {function} cb - callback that returns any error as an argument
      */
     write: (buf, pos, cb) => {
-      fd.once(() => {
-        fs.open(file, 'r+', function (err, writeFd) {
-          fs.write(writeFd, buf, 0, buf.length, pos, (err, written) => {
-            if (err == null && written !== buf.length) {
-              cb(new Error('wrote less bytes than expected:'+written+', but wanted:'+buf.length))
-            } else {
-              cb(err)
-            }
+      offset.once((_offset) => {
+        const endPos = pos + buf.length
+        const isPastOffset = endPos > _offset
+
+        if (isPastOffset) {
+          return cb(new Error(`cannot write past offset: ${endPos} > ${_offset}`))
+        }
+
+        writing(function (_writing) {
+          if (_writing === true) {
+            return
+          } else {
+            this()
+            writing.set(true)
+          }
+
+          fs.open(file, 'r+', function (err, writeFd) {
+            fs.write(writeFd, buf, 0, buf.length, pos, (err, written) => {
+              writing.set(false)
+              if (err == null && written !== buf.length) {
+                cb(new Error('wrote less bytes than expected:'+written+', but wanted:'+buf.length))
+              } else {
+                cb(err)
+              }
+            })
           })
         })
       })
     },
     truncate: function (len, cb) {
-      if(writing++) throw new Error('already writing, cannot truncate')
+      if(appending++) throw new Error('already appending, cannot truncate')
       fd.once(function (_fd) {
         if('object' === typeof _fd)
           return cb(_fd)

--- a/file.js
+++ b/file.js
@@ -26,7 +26,7 @@ module.exports = function (file, block_size, flags) {
         let shouldRemove = false
         const rm = writing(function (_writing) {
           if (shouldRemove === true) {
-            return rm()
+            return setImmediate(() => rm())
           }
 
 
@@ -100,14 +100,14 @@ module.exports = function (file, block_size, flags) {
         let shouldRemove = false
         const rm = writing(function (_writing) {
           if (shouldRemove === true) {
-            return rm()
+            return setImmediate(() => rm())
           }
 
           if (_writing === true) {
             return
           } else {
-            writing.set(true)
             shouldRemove = true
+            writing.set(true)
           }
 
           fs.open(file, 'r+', function (err, writeFd) {

--- a/file.js
+++ b/file.js
@@ -26,8 +26,7 @@ module.exports = function (file, block_size, flags) {
         if(i > max)
           return cb(new Error('aligned-block-file/file.get: requested block index was greater than max, got:'+i+', expected less than or equal to:'+max))
 
-        var buf = new Buffer(block_size)
-        buf.fill(0) //security
+        var buf = Buffer.alloc(block_size)
 
         fs.read(fd.value, buf, 0, block_size, i*block_size, function (err, bytes_read) {
           if(err) cb(err)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hashlru": "^2.1.0",
     "int53": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "obv": "0.0.1",
+    "obv": "github:fraction/obv#pass-this-rm",
     "uint48be": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hashlru": "^2.1.0",
     "int53": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "obv": "github:fraction/obv#pass-this-rm",
+    "obv": "^0.0.1",
     "uint48be": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "looper": "^4.0.0",
-    "tape": "^4.6.0"
+    "tape": "^4.10.1"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "hashlru": "^2.1.0",
-    "int53": "^0.2.4",
+    "int53": "^1.0.0",
     "mkdirp": "^0.5.1",
     "obv": "0.0.1",
-    "uint48be": "^1.0.1"
+    "uint48be": "^2.0.1"
   },
   "devDependencies": {
     "looper": "^4.0.0",

--- a/test/append.js
+++ b/test/append.js
@@ -16,20 +16,12 @@ module.exports = function (reduce) {
   var filename = '/tmp/test_block-reader_'+Date.now()
   var blocks = reduce(null)
 
-  var a = new Buffer(32)
-  a.fill('a')
-
-  var b = new Buffer(32)
-  b.fill('b')
-
-  var c = new Buffer(32)
-  c.fill('c')
-  var d = new Buffer(32)
-  d.fill('d')
-  var e = new Buffer(24)
-  e.fill('e')
-  var f = new Buffer(64)
-  f.fill('f')
+  var a = Buffer.alloc(32, 'a')
+  var b = Buffer.alloc(32, 'b')
+  var c = Buffer.alloc(32, 'c')
+  var d = Buffer.alloc(32, 'd')
+  var e = Buffer.alloc(24, 'e')
+  var f = Buffer.alloc(64, 'f')
 
   tape('append one block', function (t) {
     blocks.append(a, function (err, offset) {

--- a/test/simple.js
+++ b/test/simple.js
@@ -104,7 +104,22 @@ tape('overwrite previous data', function (t) {
         bufs.read(0, 32, function (err, bufB) {
           t.error(err)
           t.deepEqual(bufB, b)
-          t.end()
+          bufs.write(b, 1, function (err) {
+            t.ok(err, 'error if writing past last offset')
+
+            // let's make a race condition!
+            // first we'll start writing...
+            bufs.write(c, 0, function (err) {
+              t.error(err)
+            })
+
+            // and we'll start reading before it's done
+            bufs.read(0, 32, (err, bufC) => {
+              t.error(err)
+              t.deepEqual(bufC, c)
+              t.end()
+            })
+          })
         })
       })
     })

--- a/test/simple.js
+++ b/test/simple.js
@@ -5,12 +5,9 @@ var File = require('../file')
 
 var tape = require('tape')
 
-var a = new Buffer(32)
-a.fill('a')
-var b = new Buffer(32)
-b.fill('b')
-var c = new Buffer(32)
-c.fill('c')
+var a = Buffer.alloc(32, 'a')
+var b = Buffer.alloc(32, 'b')
+var c = Buffer.alloc(32, 'c')
 
 function Cache () {
   var c = []

--- a/test/simple.js
+++ b/test/simple.js
@@ -94,5 +94,23 @@ tape('read empty file', function (t) {
   })
 })
 
-
+tape('overwrite previous data', function (t) {
+  var file = '/tmp/test_block-reader_'+Date.now()
+  var bufs = Blocks(File(file, 32, 'a+'), 32)
+  bufs.append(a, function (err) {
+    t.error(err)
+    bufs.read(0, 32, function (err, bufA) {
+      t.error(err)
+      t.deepEqual(bufA, a)
+      bufs.write(b, 0, function (err) {
+        t.error(err)
+        bufs.read(0, 32, function (err, bufB) {
+          t.error(err)
+          t.deepEqual(bufB, b)
+          t.end()
+        })
+      })
+    })
+  })
+})
 


### PR DESCRIPTION
- Add .gitignore, add .npmrc, update deps 
- Add simple write method to overwrite data 
- Use non-deprecated `Buffer.alloc()` method 

The only backward-incompatible-ish change is that we're no longer throwing errors when we read empty buffers from a file. I'd especially love feedback on the `write()` method in `file.js` where I'm using a new file descriptor -- I couldn't find an elegant way to share the FD because the main one was doing read + append, whereas all we need to do is read + write.

Resolves #4 