### PR TITLE
Use rwlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "int53": "^1.0.0",
     "mkdirp": "^0.5.1",
     "obv": "^0.0.1",
+    "rwlock": "^5.0.0",
     "uint48be": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This switches from the naive handwritten queue to [rwlock](https://www.npmjs.com/package/rwlock), which is a mature and [incredibly] well-documented library that provides async read-write locks. The previous system queued reads because it was naive, but this library ensures that:

> - there may be zero or more readers at a time,
> - there may be only one writer at a time,
> - there may be no writer if there are one or more readers already.

Benchmarks are showing that this is also slightly faster than the old queue, and could *probably* be sped up by using the rwlock "keys" feature. This seems to resolve https://github.com/ssbc/ssb-db/issues/261, which I *think* was caused by `queue.shift()` getting exponentially slower as the queue grew in size (since Patchwork starts multiple concurrent streams at the same time).