### PR TITLE
Make cached read asynchronous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 10
+  - 12

--- a/blocks.js
+++ b/blocks.js
@@ -25,9 +25,11 @@ module.exports = function (file, block_size, cache) {
 
   function get(i, cb) {
     var c = cache.get(i)
-    if(Buffer.isBuffer(c))
-      cb(null, c, block_size)
-    else if(Array.isArray(cbs[i]))
+    if(Buffer.isBuffer(c)) {
+      setImmediate(function () {
+        cb(null, c, block_size)
+      }) 
+    } else if(Array.isArray(cbs[i]))
       cbs[i].push(cb)
     else {
       cbs[i] = [cb]


### PR DESCRIPTION
Make `read` always asynchronous, even if cached, to avoid stack growth in applications that recurse through calling read.

As explained in https://github.com/flumedb/aligned-block-file/issues/10